### PR TITLE
Add AASA server for Apple app-site-association testing

### DIFF
--- a/kubernetes/apps/aasa/configmap.yaml
+++ b/kubernetes/apps/aasa/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aasa-config
+  namespace: aasa
+data:
+  default.conf: |
+    server {
+        listen 80;
+        server_name _;
+
+        location = /.well-known/apple-app-site-association {
+            root /usr/share/nginx/html;
+            default_type application/json;
+        }
+    }
+  apple-app-site-association: |
+    {
+      "webcredentials": {
+        "apps": [
+          "Y3NJQL82R8.uk.co.companyshop.activities",
+          "Y3NJQL82R8.uk.co.companyshop.activities.preview"
+        ]
+      }
+    }

--- a/kubernetes/apps/aasa/deployment.yaml
+++ b/kubernetes/apps/aasa/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aasa
+  namespace: aasa
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aasa
+  template:
+    metadata:
+      labels:
+        app: aasa
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+            - name: config
+              mountPath: /usr/share/nginx/html/.well-known/apple-app-site-association
+              subPath: apple-app-site-association
+      volumes:
+        - name: config
+          configMap:
+            name: aasa-config

--- a/kubernetes/apps/aasa/httproute.yaml
+++ b/kubernetes/apps/aasa/httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: aasa
+  namespace: aasa
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - aasa.ducknet.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: aasa
+          port: 80

--- a/kubernetes/apps/aasa/kustomization.yaml
+++ b/kubernetes/apps/aasa/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: aasa
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/apps/aasa/namespace.yaml
+++ b/kubernetes/apps/aasa/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aasa

--- a/kubernetes/apps/aasa/service.yaml
+++ b/kubernetes/apps/aasa/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aasa
+  namespace: aasa
+spec:
+  selector:
+    app: aasa
+  ports:
+    - port: 80
+      targetPort: 80

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - aasa
   - garage
   - garage/dashboards
   - observability


### PR DESCRIPTION
## Summary

- Adds a new `aasa` namespace and plain-manifest app (`kubernetes/apps/aasa/`) that runs an `nginx:alpine` static server
- Serves `/.well-known/apple-app-site-association` with `Content-Type: application/json` at `https://aasa.ducknet.io`
- Wires into the existing Traefik Gateway API setup and wildcard TLS cert (`traefik-ducknet-tls`) — no new certificate resource required
- External-DNS will auto-create the `aasa.ducknet.io` DNS record from the HTTPRoute

## What's in the app

| File | Purpose |
|---|---|
| `namespace.yaml` | `aasa` namespace |
| `configmap.yaml` | nginx `default.conf` (serves AASA path with correct MIME type) + the AASA JSON file content |
| `deployment.yaml` | `nginx:alpine`, both ConfigMap keys mounted via `subPath` |
| `service.yaml` | ClusterIP on port 80 |
| `httproute.yaml` | Gateway API HTTPRoute → `traefik-gateway/websecure`, hostname `aasa.ducknet.io` |

## Reviewer notes

- HTTP → HTTPS redirect is handled at the Traefik level (existing config), so Apple's CDN will always land on HTTPS
- The nginx `location = /.well-known/apple-app-site-association` block uses `default_type application/json` — this works because the file has no extension, so nginx's mime.types lookup falls through to the explicit default
- After merge, Flux will reconcile within ~30 minutes; verify with `curl -sI https://aasa.ducknet.io/.well-known/apple-app-site-association`