### PR TITLE
Add homepage dashboard at home.ducknet.io

### DIFF
--- a/kubernetes/apps/homepage/httproute.yaml
+++ b/kubernetes/apps/homepage/httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - home.ducknet.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: homepage
+          port: 3000

--- a/kubernetes/apps/homepage/kustomization.yaml
+++ b/kubernetes/apps/homepage/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homepage
+resources:
+  - namespace.yaml
+  - release.yaml
+  - repository.yaml
+  - httproute.yaml

--- a/kubernetes/apps/homepage/namespace.yaml
+++ b/kubernetes/apps/homepage/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homepage

--- a/kubernetes/apps/homepage/release.yaml
+++ b/kubernetes/apps/homepage/release.yaml
@@ -1,0 +1,81 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  releaseName: homepage
+  chart:
+    spec:
+      chart: homepage
+      version: "^2.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: homepage
+  interval: 24h
+  install:
+    remediation:
+      retries: 3
+  values:
+    enableRbac: true
+    serviceAccount:
+      create: true
+
+    # HOMEPAGE_ALLOWED_HOSTS is required; this value replaces the chart default
+    env:
+      - name: HOMEPAGE_ALLOWED_HOSTS
+        value: "home.ducknet.io"
+
+    # We use HTTPRoute instead of the chart's ingress
+    ingress:
+      main:
+        enabled: false
+
+    config:
+      kubernetes:
+        mode: cluster
+        gateway: true
+
+      settings:
+        title: Homelab
+
+      bookmarks:
+        - Cluster:
+            - GitHub:
+                - abbr: GH
+                  href: https://github.com/jackson-hughes/homelab
+
+      services:
+        - Infrastructure:
+            - Garage (S3):
+                href: https://s3.ducknet.io
+                description: Object storage
+            - Grafana:
+                href: https://grafana.ducknet.io
+                description: Dashboards
+            - Alertmanager:
+                href: https://alerts.ducknet.io
+                description: Alerts
+            - Victoria Metrics:
+                href: https://metrics.ducknet.io
+                description: Time-series database
+            - Victoria Logs:
+                href: https://logs.ducknet.io
+                description: Logs
+
+      widgets:
+        - kubernetes:
+            cluster:
+              show: true
+              cpu: false
+              memory: false
+              showLabel: true
+              label: homelab
+            nodes:
+              show: true
+              cpu: false
+              memory: false
+              showLabel: true
+        - search:
+            provider: google
+            target: _blank

--- a/kubernetes/apps/homepage/repository.yaml
+++ b/kubernetes/apps/homepage/repository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  type: oci
+  interval: 24h
+  url: oci://ghcr.io/jameswynn/helm-charts

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
   - garage
   - garage/dashboards
+  - homepage
   - observability
   - podinfo


### PR DESCRIPTION
## Summary

- Deploys [gethomepage.dev](https://gethomepage.dev) via the `jameswynn/helm-charts` Helm chart at `home.ducknet.io`.
- Cluster-wide RBAC + Gateway API HTTPRoute auto-discovery (any namespace can opt-in via `gethomepage.dev/enabled: "true"` annotations).
- Seeded with tiles for Garage, Grafana, Alertmanager, Victoria Metrics, Victoria Logs, plus a Kubernetes overview widget (node/pod counts; CPU/memory off until metrics-server is added).
- No authentication — relies on private network reachability of `*.ducknet.io`.

## Files

- `kubernetes/apps/homepage/{namespace,repository,release,httproute,kustomization}.yaml` (new)
- `kubernetes/apps/kustomization.yaml` (added `- homepage`)

## Local validation (passed)

- `kubectl kustomize` at app + apps levels: clean.
- `helm template` with the actual values: renders ServiceAccount + ClusterRole/Binding + ConfigMap (6 keys) + Deployment (env `HOMEPAGE_ALLOWED_HOSTS=home.ducknet.io`) + Service:3000 + Secret.
- `kubectl apply --dry-run=client` against rendered output: every resource accepted.

## Test plan

- [ ] Merge → `flux reconcile kustomization apps -n flux-system --with-source`
- [ ] `kubectl -n homepage get hr,deploy,po,svc,sa` — HelmRelease Ready, pod Running, SA + ClusterRole/Binding present
- [ ] `kubectl -n homepage get httproute homepage -o jsonpath='{.status.parents[*].conditions[?(@.type=="Accepted")].status}'` returns `True`
- [ ] `kubectl auth can-i list httproutes.gateway.networking.k8s.io --as=system:serviceaccount:homepage:homepage -A` returns `yes`
- [ ] Browse `https://home.ducknet.io` from inside the network — title "Homelab", seeded tiles, kubernetes widget showing node/pod counts
- [ ] `curl -s https://home.ducknet.io/api/healthcheck` returns OK
- [ ] `kubectl -n homepage logs deploy/homepage` — no `forbidden` lines