### PR TITLE
Fix homepage HelmRepository URL (HTTP, not OCI)

### DIFF
--- a/kubernetes/apps/homepage/repository.yaml
+++ b/kubernetes/apps/homepage/repository.yaml
@@ -4,6 +4,5 @@ metadata:
   name: homepage
   namespace: homepage
 spec:
-  type: oci
   interval: 24h
-  url: oci://ghcr.io/jameswynn/helm-charts
+  url: https://jameswynn.github.io/helm-charts


### PR DESCRIPTION
## Summary

The initial #38 used \`type: oci\` against \`oci://ghcr.io/jameswynn/helm-charts\`, but jameswynn doesn't publish to GHCR — Flux failed to pull with 403. The actual repo is the GitHub Pages index at \`https://jameswynn.github.io/helm-charts\` (chart-releaser-action style; tarballs are GitHub Releases). The \`common\` subchart is vendored, so HTTP-style works without an extra HelmRepository.

## Test plan

- [ ] Merge → \`flux reconcile source helm homepage -n homepage\`
- [ ] \`kubectl -n homepage get hr homepage\` → Ready=True
- [ ] Continue verification from #38 test plan