### PR TITLE
Drop homepage kubernetes widget until metrics-server is installed

### DIFF
--- a/kubernetes/apps/homepage/release.yaml
+++ b/kubernetes/apps/homepage/release.yaml
@@ -64,18 +64,8 @@ spec:
                 description: Logs
 
       widgets:
-        - kubernetes:
-            cluster:
-              show: true
-              cpu: false
-              memory: false
-              showLabel: true
-              label: homelab
-            nodes:
-              show: true
-              cpu: false
-              memory: false
-              showLabel: true
+        # The kubernetes widget queries metrics-server unconditionally; re-enable
+        # it once metrics-server is installed on the cluster.
         - search:
             provider: google
             target: _blank


### PR DESCRIPTION
## Summary

The homepage \`kubernetes\` widget unconditionally polls metrics-server. Setting \`cpu: false, memory: false\` only suppresses display — the underlying request still runs and returns 500, surfacing as a persistent "API Error" in the dashboard header. Remove the widget until metrics-server is installed on the cluster.

## Test plan

- [ ] Merge → \`flux reconcile helmrelease homepage -n homepage\`
- [ ] Reload \`https://home.ducknet.io\` — no "API Error" banner
- [ ] \`kubectl -n homepage logs deploy/homepage --tail=50\` — no \`<widget> Error getting metrics\` lines