### PR TITLE
Add software audit skill

### DIFF
--- a/.cursor/skills/software-version-audit/SKILL.md
+++ b/.cursor/skills/software-version-audit/SKILL.md
@@ -55,7 +55,7 @@ Use the right source per artifact. Never guess.
 | Terraform providers | `registry.terraform.io/v1/providers/{namespace}/{name}/versions` | Filter stable `x.y.z`, sort numerically. **Never use `.versions[-1]` unsorted.** |
 | Terraform CLI | HashiCorp Checkpoint API or `gh release list --repo hashicorp/terraform` | Prefer latest stable, not pre-release |
 | Helm charts | Artifact Hub ` /api/v1/packages/helm/{repo}/{chart}` | Direct package endpoint |
-| GitHub releases/tags | `gh api` / `gh release view` | **Use authenticated `gh`**, not unauthenticated curl |
+| GitHub releases/tags | `gh api` / `gh release view` | **Use authenticated `gh`**, not unauthenticated curl. Tag lists are not semver-ordered — sort numerically before picking latest |
 | PyPI packages | `pypi.org/pypi/{package}/json` | Ansible toolchain |
 | Ansible Galaxy roles | `galaxy.ansible.com/api/v1/roles/` | Role version ≠ app version |
 | Garage | `git.deuxfleurs.fr` API or repo tag from `kubernetes/apps/garage/repository.yaml` | Not github.com |

--- a/.cursor/skills/software-version-audit/SKILL.md
+++ b/.cursor/skills/software-version-audit/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: software-version-audit
+description: >-
+  Audits declared, resolved, running, and upstream software versions across this
+  homelab repo (Terraform, Ansible, Flux/Kubernetes, Docker). Use when the user
+  asks for a version inventory, software audit, upgrade report, what's outdated,
+  or latest available versions for homelab components.
+---
+
+# Software Version Audit
+
+Produce an accurate version inventory for this homelab repository. Compare **declared in git**, **resolved/locked**, **running** (if accessible), and **latest upstream**.
+
+## Workflow checklist
+
+```
+- [ ] 1. Scan repo for version pins (see Repo map below)
+- [ ] 2. Classify each pin: exact / semver-range / floating
+- [ ] 3. Query upstream using canonical sources (see Lookup rules)
+- [ ] 4. Query live cluster/hosts if access is available
+- [ ] 5. Validate results before publishing (see Validation)
+- [ ] 6. Write report grouped by deployment surface
+```
+
+## Repo map — where pins live
+
+| Surface | Paths | What to extract |
+|---|---|---|
+| Terraform | `infra/terraform/**`, `.terraform-version`, `.terraform.lock.hcl` | CLI version, provider constraints, locked provider versions |
+| Ansible toolchain | `infra/ansible/requirements.txt` | `ansible`, `ansible-core` pins |
+| Ansible Galaxy roles | `infra/ansible/requirements.yml` | Role name + version/ref |
+| Ansible services | `infra/ansible/group_vars/`, `infra/ansible/playbooks/` | `*_version`, `image:`, `tag:` |
+| Flux bundle | `kubernetes/clusters/homelab/flux-system/gotk-components.yaml` | Flux version + controller image tags |
+| Helm charts | `kubernetes/**/release.yaml` | `chart.version` constraints |
+| Git sources | `kubernetes/**/repository.yaml` | `ref.tag`, `ref.branch` |
+| App values | HelmRelease `values:`, CronJob/Pod specs | Container `image:` / `tag:` |
+| Talos | `infra/metal/patches/` | Machine patches only — **cluster OS/K8s version may not be pinned here** |
+
+## Pin types
+
+Classify every component before comparing versions:
+
+- **Exact** — e.g. `2.2.0`, `v3.5.3`, `1.22.5`
+- **Semver range** — e.g. `^1.19.0` — also note the highest version allowed by the constraint
+- **Floating** — `latest`, no tag, or role ref `master`/`main` — mark **"not versioned in git"** unless runtime is queried
+
+Do not conflate **chart version**, **appVersion**, **Ansible role version**, and **container image tag**.
+
+## Lookup rules — canonical sources
+
+Use the right source per artifact. Never guess.
+
+| Artifact | Source | Notes |
+|---|---|---|
+| Terraform providers | `registry.terraform.io/v1/providers/{namespace}/{name}/versions` | Filter stable `x.y.z`, sort numerically. **Never use `.versions[-1]` unsorted.** |
+| Terraform CLI | HashiCorp Checkpoint API or `gh release list --repo hashicorp/terraform` | Prefer latest stable, not pre-release |
+| Helm charts | Artifact Hub ` /api/v1/packages/helm/{repo}/{chart}` | Direct package endpoint |
+| GitHub releases/tags | `gh api` / `gh release view` | **Use authenticated `gh`**, not unauthenticated curl |
+| PyPI packages | `pypi.org/pypi/{package}/json` | Ansible toolchain |
+| Ansible Galaxy roles | `galaxy.ansible.com/api/v1/roles/` | Role version ≠ app version |
+| Garage | `git.deuxfleurs.fr` API or repo tag from `kubernetes/apps/garage/repository.yaml` | Not github.com |
+| Container apps | GitHub/container release tag tied to image | Avoid Docker Hub "latest tags" API — unreliable |
+| Filebeat/Elastic | Elastic artifacts HEAD check or beats releases | Role uses `8.x` loosely in `group_vars/all` |
+
+### Known homelab-specific sources
+
+- Homepage chart: `jameswynn.github.io/helm-charts` (not generic Artifact Hub search results)
+- Garage GitRepository: `https://git.deuxfleurs.fr/Deuxfleurs/garage.git` tag `v2.3.0`
+- AWS provider pinned in `infra/terraform/aws/terraform.tf` — expect 5.x in repo; upstream is 6.x
+
+## Live runtime queries (when cluster/host access available)
+
+If unavailable, label **Running: N/A** and state that explicitly.
+
+```bash
+flux get helmreleases -A
+kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.spec.containers[*].image}{"\n"}{end}' | sort -u
+talosctl version          # or equivalent for cluster OS/K8s
+terraform version
+```
+
+For Ansible Docker hosts, running image versions require host access (`docker inspect` / `docker ps`).
+
+## Validation — run before publishing
+
+- If `latest < declared`, recheck the source
+- If latest jumped ≥1 major, verify source and report **both** overall latest and **same-major latest**
+- If two sources disagree, prefer the canonical source and note the conflict
+- Sanity-check: Terraform AWS provider (expect 6.x latest), Flux bundle, one Helm chart
+- Failed lookups → mark **"lookup failed"**, do not invent a version
+- Huge gaps (e.g. node_exporter `1.3.1` vs upstream `1.11.x`) → verify the declared value's meaning (Ansible var vs binary)
+
+## Report format
+
+Group by deployment surface:
+
+1. Infrastructure tooling (Terraform, Ansible)
+2. Flux / GitOps
+3. Kubernetes Helm charts & app pins
+4. Ansible-managed services & Docker images
+5. Ansible Galaxy roles
+
+### Row template
+
+| Component | Declared | Resolved/Locked | Running | Latest stable | Latest same major | Pin type | Status | Source |
+
+**Status values:** Current / Behind / Floating / Lookup failed / Major available
+
+### End sections (required)
+
+- **Biggest gaps** — prioritized: security patches, exact pins far behind, floating images
+- **Not in repo** — components with no declared version (e.g. Talos/K8s if unpinned)
+- **Methodology** — sources used, whether `gh` auth was used, cluster queried or not, timestamp
+
+## Components commonly unpinned in this repo
+
+Treat separately; do not imply precision without runtime data:
+
+- Docker: `prom/prometheus`, `grafana/grafana`, `prom/alertmanager`, `prom/consul-exporter`, `golift/unifi-poller`, `ghcr.io/onedr0p/exportarr`
+- Media stack: `qmcgaw/gluetun`, `linuxserver/*` in `infra/ansible/playbooks/docker-services/templates/media-compose.yml.j2`
+- CronJob: `curlimages/curl:latest` in `kubernetes/apps/observability/healthchecks-io/cronjob.yaml`
+- Roles on `master`/`main`: `ansible-consul`, custom `jhughes01/*` roles, `virtUOS/ansible-loki`
+
+## Same-major comparisons (when relevant)
+
+Report both columns when a major jump is risky:
+
+| Component | Why |
+|---|---|
+| AWS provider (5.41.0) | Latest 5.x vs 6.x |
+| Consul (1.22.5) | Latest 1.22.x vs 2.0.0 |
+| Kafka (3.7.0) | Latest 3.x vs 4.x |
+| Terraform CLI (1.13.3) | Latest 1.13.x vs latest stable |
+| Redis sidecar (7.0.6 in podinfo) | Latest 7.0.x vs current Redis major |
+
+## Additional reference
+
+For command snippets and API examples, see [reference.md](reference.md).

--- a/.cursor/skills/software-version-audit/reference.md
+++ b/.cursor/skills/software-version-audit/reference.md
@@ -45,10 +45,18 @@ curl -sL "https://artifacthub.io/api/v1/packages/helm/jetstack/cert-manager" | j
 curl -sL "https://artifacthub.io/api/v1/packages/helm/victoriametrics/victoria-metrics-k8s-stack" | jq -r .version
 ```
 
-Homepage chart (jameswynn — not generic search):
+Homepage chart (jameswynn — not generic search). Helm `index.yaml` lists each chart under a two-space key with `-` list items; chart `version` may be on the `-` line or indented with four spaces (dependency `version` fields use six). Scope to the `homepage` section and read the first (newest) entry only:
 
 ```bash
-curl -sL https://jameswynn.github.io/helm-charts/index.yaml | awk '/^  homepage:/{f=1} f && /^    version:/{print; exit}'
+curl -sL https://jameswynn.github.io/helm-charts/index.yaml | awk '
+  /^  homepage:/ { in_chart=1; next }
+  in_chart && /^  [a-zA-Z0-9_-]+:$/ { exit }
+  in_chart && /^  - / && !entry {
+    entry=1
+    if (match($0, /version:[[:space:]]*/)) { print substr($0, RSTART+RLENGTH); exit }
+  }
+  in_chart && entry && /^    version:/ { print $2; exit }
+'
 ```
 
 ## GitHub (authenticated via gh)

--- a/.cursor/skills/software-version-audit/reference.md
+++ b/.cursor/skills/software-version-audit/reference.md
@@ -56,7 +56,11 @@ curl -sL https://jameswynn.github.io/helm-charts/index.yaml | awk '/^  homepage:
 ```bash
 gh release view --repo fluxcd/flux2 --json tagName -q .tagName
 gh release view --repo hashicorp/consul --json tagName -q .tagName
-gh api repos/apache/kafka/tags --paginate -q '.[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name' | head -1
+# Kafka has no GitHub releases; use tags. Sort semver numerically — never `head -1` (API/lex order ≠ latest).
+gh api repos/apache/kafka/tags --paginate -q '.[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name' \
+  | sort -t. -k1,1n -k2,2n -k3,3n | tail -1
+gh api repos/apache/kafka/tags --paginate -q '.[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name' \
+  | sort -t. -k1,1n -k2,2n -k3,3n | grep '^3\.' | tail -1  # latest 3.x (same-major)
 gh release list --repo hashicorp/consul --limit 20 | awk '/^v1\./{print $1; exit}'  # latest 1.x
 ```
 
@@ -98,6 +102,7 @@ docker inspect -f '{{.Config.Image}}' prometheus
 | Docker Hub tag looks wrong (e.g. prometheus `0.15.0`) | Switch to GitHub releases |
 | GitHub 403 rate limit | Use `gh api` with auth, or wait/retry |
 | Registry `.versions[-1]` ≠ expected | Re-sort — array is not semver-ordered |
+| GitHub tags `head -1` or API page order | Semver-sort numerically (`sort -t. -k1,1n …`) before taking latest |
 | Ansible `*_version` var | Confirm whether it's app binary, role default, or collection pin |
 
 ## HelmRelease files in this repo

--- a/.cursor/skills/software-version-audit/reference.md
+++ b/.cursor/skills/software-version-audit/reference.md
@@ -69,7 +69,9 @@ gh api repos/apache/kafka/tags --paginate -q '.[] | select(.name | test("^[0-9]+
   | sort -t. -k1,1n -k2,2n -k3,3n | tail -1
 gh api repos/apache/kafka/tags --paginate -q '.[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name' \
   | sort -t. -k1,1n -k2,2n -k3,3n | grep '^3\.' | tail -1  # latest 3.x (same-major)
-gh release list --repo hashicorp/consul --limit 20 | awk '/^v1\./{print $1; exit}'  # latest 1.x
+# Same-major: filter tagName, not tabular column 1 (release title). Paginate — list order ≠ semver.
+gh api repos/hashicorp/consul/releases --paginate -q '.[] | select(.prerelease == false) | .tag_name' \
+  | grep -E '^v1\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1  # latest 1.x
 ```
 
 ## PyPI & Galaxy
@@ -111,6 +113,7 @@ docker inspect -f '{{.Config.Image}}' prometheus
 | GitHub 403 rate limit | Use `gh api` with auth, or wait/retry |
 | Registry `.versions[-1]` ≠ expected | Re-sort — array is not semver-ordered |
 | GitHub tags `head -1` or API page order | Semver-sort numerically (`sort -t. -k1,1n …`) before taking latest |
+| `gh release list` tabular output for same-major | Column 1 is release **title** (`name`), not `tagName`; use `--json tagName` or `gh api …/releases` |
 | Ansible `*_version` var | Confirm whether it's app binary, role default, or collection pin |
 
 ## HelmRelease files in this repo

--- a/.cursor/skills/software-version-audit/reference.md
+++ b/.cursor/skills/software-version-audit/reference.md
@@ -1,0 +1,118 @@
+# Software Version Audit — Reference
+
+Command snippets and API patterns for this homelab repo.
+
+## Repo grep patterns
+
+```bash
+# Broad scan for version pins
+rg 'version:|tag:|image:|consul_version|kafka_version|node_exporter_version|filebeat_version' \
+  infra/ansible kubernetes infra/terraform --glob '*.{yaml,yml,tf,hcl,txt,j2}'
+```
+
+## Terraform Registry (proper semver sort)
+
+```python
+import json, re, urllib.request
+
+def latest_stable_provider(namespace, name, declared_major=None):
+    url = f"https://registry.terraform.io/v1/providers/{namespace}/{name}/versions"
+    data = json.load(urllib.request.urlopen(url))
+    stable = sorted(
+        {v["version"] for v in data["versions"] if re.fullmatch(r"\d+\.\d+\.\d+", v["version"])},
+        key=lambda s: tuple(map(int, s.split("."))),
+    )
+    latest = stable[-1]
+    same_major = None
+    if declared_major is not None:
+        in_major = [v for v in stable if v.startswith(f"{declared_major}.")]
+        same_major = in_major[-1] if in_major else None
+    return {"latest": latest, "same_major": same_major, "all_stable": stable}
+
+# Example: latest_stable_provider("hashicorp", "aws", declared_major="5")
+# → latest 6.x.x, same_major latest 5.x.x (pass major from declared pin, e.g. "5" from 5.41.0)
+```
+
+```bash
+# Terraform CLI
+curl -sL https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version
+```
+
+## Helm charts (Artifact Hub)
+
+```bash
+curl -sL "https://artifacthub.io/api/v1/packages/helm/jetstack/cert-manager" | jq -r .version
+curl -sL "https://artifacthub.io/api/v1/packages/helm/victoriametrics/victoria-metrics-k8s-stack" | jq -r .version
+```
+
+Homepage chart (jameswynn — not generic search):
+
+```bash
+curl -sL https://jameswynn.github.io/helm-charts/index.yaml | awk '/^  homepage:/{f=1} f && /^    version:/{print; exit}'
+```
+
+## GitHub (authenticated via gh)
+
+```bash
+gh release view --repo fluxcd/flux2 --json tagName -q .tagName
+gh release view --repo hashicorp/consul --json tagName -q .tagName
+gh api repos/apache/kafka/tags --paginate -q '.[] | select(.name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .name' | head -1
+gh release list --repo hashicorp/consul --limit 20 | awk '/^v1\./{print $1; exit}'  # latest 1.x
+```
+
+## PyPI & Galaxy
+
+```bash
+curl -sL https://pypi.org/pypi/ansible/json | jq -r .info.version
+curl -sL "https://galaxy.ansible.com/api/v1/roles/?owner__username=geerlingguy&name=docker" \
+  | jq -r '.results[0].summary_fields.versions[0].name'
+```
+
+## Forgejo (Garage)
+
+```bash
+curl -sL 'https://git.deuxfleurs.fr/api/v1/repos/Deuxfleurs/garage/releases?limit=1' | jq -r '.[0].tag_name'
+```
+
+## Flux / Kubernetes runtime
+
+```bash
+flux get helmreleases -A
+flux get sources git -A
+kubectl get pods -A -o custom-columns='NS:.metadata.namespace,IMAGE:.spec.containers[*].image' --no-headers | sort -u
+```
+
+## Ansible Docker hosts
+
+```bash
+docker ps --format '{{.Names}}\t{{.Image}}'
+docker inspect -f '{{.Config.Image}}' prometheus
+```
+
+## Validation heuristics
+
+| Signal | Action |
+|---|---|
+| `latest < declared` | Recheck source and sort logic |
+| Major version jump | Confirm canonical source; add same-major column |
+| Docker Hub tag looks wrong (e.g. prometheus `0.15.0`) | Switch to GitHub releases |
+| GitHub 403 rate limit | Use `gh api` with auth, or wait/retry |
+| Registry `.versions[-1]` ≠ expected | Re-sort — array is not semver-ordered |
+| Ansible `*_version` var | Confirm whether it's app binary, role default, or collection pin |
+
+## HelmRelease files in this repo
+
+| File | Chart |
+|---|---|
+| `kubernetes/infrastructure/controllers/cert-manager/release.yaml` | cert-manager |
+| `kubernetes/infrastructure/controllers/external-secrets/release.yaml` | external-secrets |
+| `kubernetes/infrastructure/config/external-dns/release.yaml` | external-dns |
+| `kubernetes/infrastructure/controllers/metallb/release.yaml` | metallb |
+| `kubernetes/infrastructure/controllers/openebs/release.yaml` | openebs |
+| `kubernetes/infrastructure/controllers/traefik/release.yaml` | traefik |
+| `kubernetes/infrastructure/controllers/victoria-metrics-operator/operator-release.yaml` | victoria-metrics-operator |
+| `kubernetes/apps/observability/victoria-metrics/release.yaml` | victoria-metrics-k8s-stack |
+| `kubernetes/apps/observability/prometheus-node-exporter/release.yaml` | prometheus-node-exporter |
+| `kubernetes/apps/homepage/release.yaml` | homepage |
+| `kubernetes/apps/podinfo/release.yaml` | podinfo |
+| `kubernetes/apps/garage/release.yaml` | garage (Git chart source) |

--- a/.cursor/skills/software-version-audit/reference.md
+++ b/.cursor/skills/software-version-audit/reference.md
@@ -25,7 +25,8 @@ def latest_stable_provider(namespace, name, declared_major=None):
     latest = stable[-1]
     same_major = None
     if declared_major is not None:
-        in_major = [v for v in stable if v.startswith(f"{declared_major}.")]
+        major = str(declared_major)
+        in_major = [v for v in stable if v.split(".", 1)[0] == major]
         same_major = in_major[-1] if in_major else None
     return {"latest": latest, "same_major": same_major, "all_stable": stable}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only Cursor skill files; no runtime, infrastructure, or application code changes.
> 
> **Overview**
> Adds a new Cursor agent skill **software-version-audit** under `.cursor/skills/` so assistants can run structured homelab version inventories on request.
> 
> **`SKILL.md`** defines the end-to-end workflow: where pins live in this repo (Terraform, Ansible, Flux/Kubernetes, Docker), pin classification (exact / range / floating), canonical upstream lookup rules, optional live cluster/host queries, validation checks, and a standardized report layout (including same-major comparisons and known unpinned components).
> 
> **`reference.md`** complements it with copy-paste commands and APIs (registry semver sorting, Artifact Hub, authenticated `gh`, PyPI/Galaxy, Garage Forgejo, Flux/kubectl/docker) plus a table of in-repo `HelmRelease` paths and lookup pitfalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f406036ff9aecabfc70c0e0ccf219456a56263cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->